### PR TITLE
Multiple chart selections

### DIFF
--- a/src/app/GlobalRedux/Features/CoinChartSlice/index.tsx
+++ b/src/app/GlobalRedux/Features/CoinChartSlice/index.tsx
@@ -29,8 +29,10 @@ export const fetchCoinChart = createAsyncThunk(
     }: { coinId: string; currency: string; timePeriod: string },
     thunkApi
   ) => {
-    const COIN_URL = `https://api.coingecko.com/api/v3/coins/${coinId}/market_chart?vs_currency=${currency}&days=${timePeriod}`;
-    return fetchData(COIN_URL);
+    const COIN_URL = `https://api.coingecko.com/api/v3/coins/${coinId}/market_chart?vs_currency=${currency}&days=${timePeriod}&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`;
+    const response = await fetch(COIN_URL);
+    const data = await response.json();
+    return { coinId, timePeriod, data };
   }
 );
 
@@ -51,6 +53,7 @@ const coinChartSlice = createSlice({
         state.error = "";
       })
       .addCase(fetchCoinChart.fulfilled, (state, action) => {
+        console.log(action.payload);
         const { coinId, timePeriod, data } = action.payload;
         if (!state.charts[coinId]) {
           state.charts[coinId] = {};

--- a/src/app/GlobalRedux/Features/CoinChartSlice/index.tsx
+++ b/src/app/GlobalRedux/Features/CoinChartSlice/index.tsx
@@ -53,7 +53,6 @@ const coinChartSlice = createSlice({
         state.error = "";
       })
       .addCase(fetchCoinChart.fulfilled, (state, action) => {
-        console.log(action.payload);
         const { coinId, timePeriod, data } = action.payload;
         if (!state.charts[coinId]) {
           state.charts[coinId] = {};

--- a/src/app/GlobalRedux/Features/CoinChartSlice/index.tsx
+++ b/src/app/GlobalRedux/Features/CoinChartSlice/index.tsx
@@ -3,7 +3,7 @@
 import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
 import { fetchData } from "@/utils/conversions";
 
-interface ChartData {
+export interface ChartData {
   prices: number[][];
   market_caps: number[][];
   total_volumes: number[][];

--- a/src/app/GlobalRedux/Features/CoinChartSlice/index.tsx
+++ b/src/app/GlobalRedux/Features/CoinChartSlice/index.tsx
@@ -32,6 +32,7 @@ export const fetchCoinChart = createAsyncThunk(
     const COIN_URL = `https://api.coingecko.com/api/v3/coins/${coinId}/market_chart?vs_currency=${currency}&days=${timePeriod}&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`;
     const response = await fetch(COIN_URL);
     const data = await response.json();
+    //Need to return arguments of function with payload
     return { coinId, timePeriod, data };
   }
 );

--- a/src/app/GlobalRedux/Features/CurrencySlice/index.ts
+++ b/src/app/GlobalRedux/Features/CurrencySlice/index.ts
@@ -1,28 +1,28 @@
 `use client`;
 
-import { createSlice } from "@reduxjs/toolkit"
+import { createSlice } from "@reduxjs/toolkit";
 
-
-
-const initialState = {
-    currency: "usd",
-    currentChart: "bitcoin",
-    loading: false,
-    error: "",
+interface CurrencyState {
+  currency: string;
+  loading: boolean;
+  error: string;
 }
 
-const currencySlice = createSlice({
-    name: "currency",
-    initialState,
-    reducers: {
-            changeCurrency (state, action) {
-                state.currency = action.payload
-            },
-            changeChart (state, action) {
-                state.currentChart = action.payload
-            }
-    }
-})
+const initialState: CurrencyState = {
+  currency: "usd",
+  loading: false,
+  error: "",
+};
 
-export const {changeCurrency, changeChart} = currencySlice.actions
-export default currencySlice.reducer
+const currencySlice = createSlice({
+  name: "currency",
+  initialState,
+  reducers: {
+    changeCurrency(state, action) {
+      state.currency = action.payload;
+    },
+  },
+});
+
+export const { changeCurrency } = currencySlice.actions;
+export default currencySlice.reducer;

--- a/src/app/GlobalRedux/Features/CurrentChartSlice/index.ts
+++ b/src/app/GlobalRedux/Features/CurrentChartSlice/index.ts
@@ -1,0 +1,24 @@
+`use client`;
+
+import { createSlice } from "@reduxjs/toolkit";
+
+interface CurrentChartState {
+  currentCharts: string[];
+}
+
+const initialState: CurrentChartState = {
+  currentCharts: [],
+};
+
+const currentChartsSlice = createSlice({
+  name: "currentCharts",
+  initialState,
+  reducers: {
+    changeCurrentCharts(state, action) {
+      state.currentCharts = action.payload;
+    },
+  },
+});
+
+export const { changeCurrentCharts } = currentChartsSlice.actions;
+export default currentChartsSlice.reducer;

--- a/src/app/GlobalRedux/Features/GlobalSlice/index.ts
+++ b/src/app/GlobalRedux/Features/GlobalSlice/index.ts
@@ -38,6 +38,7 @@ export const fetchGlobal = createAsyncThunk(
   "global/getData",
   async (thunkApi) => {
     const GLOBAL_URL = `https://api.coingecko.com/api/v3/global`;
+    console.log("Global fetch requested");
     return fetchData(GLOBAL_URL);
   }
 );

--- a/src/app/GlobalRedux/Features/GlobalSlice/index.ts
+++ b/src/app/GlobalRedux/Features/GlobalSlice/index.ts
@@ -38,7 +38,6 @@ export const fetchGlobal = createAsyncThunk(
   "global/getData",
   async (thunkApi) => {
     const GLOBAL_URL = `https://api.coingecko.com/api/v3/global`;
-    console.log("Global fetch requested");
     return fetchData(GLOBAL_URL);
   }
 );

--- a/src/app/GlobalRedux/Features/MarketTableSlice/index.ts
+++ b/src/app/GlobalRedux/Features/MarketTableSlice/index.ts
@@ -6,7 +6,8 @@ import { fetchData } from "@/utils/conversions";
 export const fetchCoins = createAsyncThunk(
   "coins/getCoins",
   async (currency: string, thunkApi) => {
-    const COIN_URL = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=20&page=1&sparkline=true&price_change_percentage=1h%2C24h%2C7d&locale=en`;
+    const COIN_URL = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=20&page=1&sparkline=true&price_change_percentage=1h%2C24h%2C7d&locale=en&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`;
+    console.log("Market Table fetch requested");
     return fetchData(COIN_URL);
   }
 );

--- a/src/app/GlobalRedux/Features/MarketTableSlice/index.ts
+++ b/src/app/GlobalRedux/Features/MarketTableSlice/index.ts
@@ -7,7 +7,6 @@ export const fetchCoins = createAsyncThunk(
   "coins/getCoins",
   async (currency: string, thunkApi) => {
     const COIN_URL = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=20&page=1&sparkline=true&price_change_percentage=1h%2C24h%2C7d&locale=en&x_cg_demo_api_key=${process.env.NEXT_PUBLIC_API_KEY}`;
-    console.log("Market Table fetch requested");
     return fetchData(COIN_URL);
   }
 );

--- a/src/app/GlobalRedux/store.ts
+++ b/src/app/GlobalRedux/store.ts
@@ -6,6 +6,7 @@ import marketTableReducer from "./Features/MarketTableSlice";
 import currencyReducer from "./Features/CurrencySlice";
 import coinChartReducer from "./Features/CoinChartSlice";
 import globalReducer from "./Features/GlobalSlice";
+import currentChartsReducer from "./Features/CurrentChartSlice";
 
 export const store = configureStore({
   reducer: {
@@ -13,6 +14,7 @@ export const store = configureStore({
     currency: currencyReducer,
     globalData: globalReducer,
     coinChart: coinChartReducer,
+    currentCharts: currentChartsReducer,
   },
 });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,7 +52,6 @@ const Home = () => {
       <Navbar />
       <CoinChartsContainer>
         <CoinCharts
-          coins={coins}
           coinPriceData={{ prices: coinPriceData as [number, number][] }}
           coinVolumeData={{ prices: coinVolumeData as [number, number][] }}
           currentCoin={currentCoin}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,13 +34,13 @@ const Home = () => {
     (state) => state.currency
   );
 
-  useEffect(() => {
-    dispatch(fetchCoins(currentCurrency));
-  }, [currentCurrency]);
-
   const { coins, loading, error } = useSelector(
     (state: RootState) => state.marketTable
   );
+
+  useEffect(() => {
+    dispatch(fetchCoins(currentCurrency));
+  }, [currentCurrency]);
 
   const coinPriceData = BitcoinDailyData.prices;
   const coinVolumeData = BitcoinDailyData.total_volumes;

--- a/src/components/ChartSelector/index.tsx
+++ b/src/components/ChartSelector/index.tsx
@@ -76,7 +76,6 @@ export const ChartSelector: React.FC<ChartSelectorProps> = ({
 
   const handleSelection = (selection: string) => {
     if (selection === currentSelection) return;
-
     setIsTransitioning(true);
     setCurrentSelection(selection);
     setTimeout(() => {

--- a/src/components/CoinCharts/index.tsx
+++ b/src/components/CoinCharts/index.tsx
@@ -4,24 +4,16 @@ import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch, RootState } from "@/app/GlobalRedux/store";
 import { useAppSelector } from "@/app/GlobalRedux/store";
 import {
-  formatDate,
-  formatChartNumber,
-  getCurrencySymbol,
-} from "@/utils/formatting";
-import {
   fetchCoinChart,
   ChartData,
 } from "@/app/GlobalRedux/Features/CoinChartSlice";
 import { ChartSelector } from "@/components/ChartSelector";
-import CurrencySlice, {
-  changeChart,
-} from "@/app/GlobalRedux/Features/CurrencySlice";
+import CurrencySlice from "@/app/GlobalRedux/Features/CurrencySlice";
 import { ChartInfo } from "../ChartInfo";
 import { CoinSelectorCarousel } from "../CoinSelectorCarousel";
 import { ModularChart } from "../ModularChart";
 import { CoinDataProps } from "../ModularChart";
 import { Coin } from "../../../interfaces";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 type CoinChartsProps = {
   coinPriceData: CoinDataProps;
@@ -107,21 +99,20 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
   const timePeriod = "1";
 
   useEffect(() => {
-    const fetchChartDataForStore = async () => {
-      for (const chart of currentCharts) {
-        if (!charts[chart] || !charts[chart][timePeriod]) {
-          await dispatch(
-            fetchCoinChart({
-              coinId: chart,
-              currency,
-              timePeriod,
-            })
-          );
-        }
-      }
+    const fetchChartDataForStore = async (chart: string) => {
+      await dispatch(
+        fetchCoinChart({
+          coinId: chart,
+          currency,
+          timePeriod,
+        })
+      );
     };
-    fetchChartDataForStore();
-
+    for (const chart of currentCharts) {
+      if (!charts[chart] || !charts[chart][timePeriod]) {
+        fetchChartDataForStore(chart);
+      }
+    }
     const currentChartDataArray = currentCharts.map((chart) => {
       if (charts[chart] && charts[chart][timePeriod]) {
         return charts[chart][timePeriod];
@@ -135,7 +126,7 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
       <CoinSelectorCarousel coins={coins} currentCurrency={currency} />
       <ChartsContainer>
         <SingleChartContainer>
-          <ModularChart coinData={currentChartData} isPrice={true} />
+          <ModularChart coinData={currentChartData} isLine={true} />
           {currentCoin && (
             <ChartInfo
               currentCoin={currentCoin}
@@ -145,7 +136,7 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
           )}
         </SingleChartContainer>
         <SingleChartContainer>
-          <ModularChart coinData={currentChartData} isPrice={false} />
+          <ModularChart coinData={currentChartData} isLine={false} />
           {currentCoin && (
             <ChartInfo
               currentCoin={currentCoin}

--- a/src/components/CoinCharts/index.tsx
+++ b/src/components/CoinCharts/index.tsx
@@ -10,10 +10,12 @@ import {
   formatChartNumber,
   getCurrencySymbol,
 } from "@/utils/formatting";
-import { ChartInfo } from "../ChartInfo";
-
+import { fetchCoinChart } from "@/app/GlobalRedux/Features/CoinChartSlice";
 import { ChartSelector } from "@/components/ChartSelector";
-import { changeChart } from "@/app/GlobalRedux/Features/CurrencySlice";
+import CurrencySlice, {
+  changeChart,
+} from "@/app/GlobalRedux/Features/CurrencySlice";
+import { ChartInfo } from "../ChartInfo";
 import { CoinSelectorCarousel } from "../CoinSelectorCarousel";
 import { ModularChart } from "../ModularChart";
 import { CoinDataProps } from "../ModularChart";
@@ -25,7 +27,6 @@ type CoinChartsProps = {
   coinVolumeData: CoinDataProps;
   currentCoin: Coin;
   currentCurrency: string;
-  coins: Coin[];
 };
 
 const ComponentContainer = tw.div`
@@ -82,18 +83,27 @@ const ChartDate = tw.div`
 `;
 
 export const CoinCharts: React.FC<CoinChartsProps> = ({
-  coins,
   coinPriceData,
   coinVolumeData,
   currentCoin,
 }) => {
   const dispatch = useDispatch<AppDispatch>();
-  const { currency: currentCurrency, currentChart } = useAppSelector(
-    (state) => state.currency
+  const { currency, currentChart } = useAppSelector((state) => state.currency);
+
+  const { coins, loading, error } = useSelector(
+    (state: RootState) => state.marketTable
   );
 
-  const handleCoinChartSelection = (selection: string) => {
-    dispatch(changeChart(selection));
+  const { charts } = useSelector((state: RootState) => state.coinChart);
+
+  const timePeriod = "1D";
+
+  const handleCoinChartSelection = (selections: string[]) => {
+    selections.forEach((selection) => {
+      if (!charts[selection][timePeriod]) {
+        dispatch(fetchCoinChart({ coinId: selection, currency, timePeriod }));
+      }
+    });
   };
 
   return (
@@ -101,7 +111,7 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
       <CoinSelectorCarousel
         coins={coins}
         currentChart={currentChart}
-        currentCurrency={currentCurrency}
+        currentCurrency={currency}
         handleCoinChartSelection={handleCoinChartSelection}
       />
       <ChartsContainer>
@@ -114,7 +124,7 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
           {currentCoin && (
             <ChartInfo
               currentCoin={currentCoin}
-              currentCurrency={currentCurrency}
+              currentCurrency={currency}
               isprice={true}
             />
           )}
@@ -128,7 +138,7 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
           {currentCoin && (
             <ChartInfo
               currentCoin={currentCoin}
-              currentCurrency={currentCurrency}
+              currentCurrency={currency}
               isprice={false}
             />
           )}

--- a/src/components/CoinCharts/index.tsx
+++ b/src/components/CoinCharts/index.tsx
@@ -8,7 +8,10 @@ import {
   formatChartNumber,
   getCurrencySymbol,
 } from "@/utils/formatting";
-import { fetchCoinChart } from "@/app/GlobalRedux/Features/CoinChartSlice";
+import {
+  fetchCoinChart,
+  ChartData,
+} from "@/app/GlobalRedux/Features/CoinChartSlice";
 import { ChartSelector } from "@/components/ChartSelector";
 import CurrencySlice, {
   changeChart,
@@ -85,7 +88,7 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
   coinVolumeData,
   currentCoin,
 }) => {
-  const [currentChartData, setCurrentChartData] = useState([]);
+  const [currentChartData, setCurrentChartData] = useState<ChartData[]>([]);
   const dispatch = useDispatch<AppDispatch>();
 
   const { currency, currentChart } = useAppSelector((state) => state.currency);
@@ -110,6 +113,7 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
     const currentChartDataArray = selections.map((selection) => {
       return charts[selection][timePeriod];
     });
+    setCurrentChartData(currentChartDataArray);
   };
 
   return (

--- a/src/components/CoinCharts/index.tsx
+++ b/src/components/CoinCharts/index.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
 import tw from "tailwind-styled-components";
-
 import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch, RootState } from "@/app/GlobalRedux/store";
 import { useAppSelector } from "@/app/GlobalRedux/store";
-
 import {
   formatDate,
   formatChartNumber,
@@ -87,7 +85,9 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
   coinVolumeData,
   currentCoin,
 }) => {
+  const [currentChartData, setCurrentChartData] = useState([]);
   const dispatch = useDispatch<AppDispatch>();
+
   const { currency, currentChart } = useAppSelector((state) => state.currency);
 
   const { coins, loading, error } = useSelector(
@@ -98,11 +98,17 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
 
   const timePeriod = "1D";
 
-  const handleCoinChartSelection = (selections: string[]) => {
-    selections.forEach((selection) => {
-      if (!charts[selection][timePeriod]) {
-        dispatch(fetchCoinChart({ coinId: selection, currency, timePeriod }));
+  const handleCoinChartSelection = async (selections: string[]) => {
+    for (const selection of selections) {
+      if (!charts[selection] || !charts[selection][timePeriod]) {
+        await dispatch(
+          fetchCoinChart({ coinId: selection, currency, timePeriod })
+        );
       }
+    }
+
+    const currentChartDataArray = selections.map((selection) => {
+      return charts[selection][timePeriod];
     });
   };
 

--- a/src/components/CoinCharts/index.tsx
+++ b/src/components/CoinCharts/index.tsx
@@ -90,9 +90,9 @@ export const CoinCharts: React.FC<CoinChartsProps> = () => {
   const { currency } = useAppSelector((state) => state.currency);
   const { charts } = useAppSelector((state) => state.coinChart);
   const { currentCharts } = useAppSelector((state) => state.currentCharts);
-  const { coins, loading, error } = useAppSelector(
-    (state) => state.marketTable
-  );
+  const { coins } = useAppSelector((state) => state.marketTable) as {
+    coins: Coin[];
+  };
 
   const timePeriod = "1";
 

--- a/src/components/CoinCharts/index.tsx
+++ b/src/components/CoinCharts/index.tsx
@@ -81,13 +81,11 @@ const ChartDate = tw.div`
   dark:text-opacity-50
 `;
 
-export const CoinCharts: React.FC<CoinChartsProps> = ({
-  coinPriceData,
-  coinVolumeData,
-  currentCoin,
-}) => {
-  const [currentChartData, setCurrentChartData] = useState<ChartData[]>([]);
+export const CoinCharts: React.FC<CoinChartsProps> = () => {
   const dispatch = useDispatch<AppDispatch>();
+
+  const [currentChartData, setCurrentChartData] = useState<ChartData[]>([]);
+  const [currentCoin, setCurrentCoin] = useState<Coin>();
 
   const { currency } = useAppSelector((state) => state.currency);
   const { charts } = useAppSelector((state) => state.coinChart);
@@ -118,6 +116,14 @@ export const CoinCharts: React.FC<CoinChartsProps> = ({
         return charts[chart][timePeriod];
       } else return EmptyChartData;
     });
+
+    if (coins && currentCharts[0]) {
+      const currentCoinHolder = coins.find(
+        (coin) => coin.id === currentCharts[0]
+      );
+      setCurrentCoin(currentCoinHolder);
+    }
+
     setCurrentChartData(currentChartDataArray);
   }, [currentCharts, charts]);
 

--- a/src/components/CoinSelectorCarousel/index.tsx
+++ b/src/components/CoinSelectorCarousel/index.tsx
@@ -163,8 +163,8 @@ export const CoinSelectorCarousel = ({
       if (currentChart.length >= 3) {
         currentCharts.shift();
       }
+      currentCharts.push(selection);
     }
-    currentCharts.push(selection);
     handleCoinChartSelection(currentCharts);
     setSelectedCoins(currentCharts);
   };

--- a/src/components/CoinSelectorCarousel/index.tsx
+++ b/src/components/CoinSelectorCarousel/index.tsx
@@ -138,8 +138,6 @@ export const CoinSelectorCarousel = ({
   coins,
   currentCurrency,
 }: ChartSelectorProps) => {
-  const [selectedCoins, setSelectedCoins] = useState<string[]>([]);
-
   const dispatch = useDispatch();
 
   const { currentCharts } = useAppSelector((state) => state.currentCharts);

--- a/src/components/CoinSelectorCarousel/index.tsx
+++ b/src/components/CoinSelectorCarousel/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import tw from "tailwind-styled-components";
 import Image from "next/image";
 import { Url } from "next/dist/shared/lib/router/router";
@@ -13,7 +13,7 @@ type ChartSelectorProps = {
   coins: Coin[];
   currentChart: string;
   currentCurrency: string;
-  handleCoinChartSelection: (selection: string) => void;
+  handleCoinChartSelection: (selection: string[]) => void;
 };
 
 type CoinCardProps = {
@@ -153,8 +153,20 @@ export const CoinSelectorCarousel = ({
   currentCurrency,
   handleCoinChartSelection,
 }: ChartSelectorProps) => {
+  const [selectedCoins, setSelectedCoins] = useState<string[]>([]);
+
   const handleSelection = (selection: string) => {
-    handleCoinChartSelection(selection);
+    let currentCharts = [...selectedCoins];
+    if (currentCharts.includes(selection)) {
+      currentCharts = currentCharts.filter((el) => el !== selection);
+    } else {
+      if (currentChart.length >= 3) {
+        currentCharts.shift();
+      }
+    }
+    currentCharts.push(selection);
+    handleCoinChartSelection(currentCharts);
+    setSelectedCoins(currentCharts);
   };
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -182,7 +194,7 @@ export const CoinSelectorCarousel = ({
       <ChartSelectorinnerContainer>
         <ChartSelectorInnerContainer ref={scrollContainerRef}>
           {coins.map((coin: Coin) => {
-            const isCurrent = coin.name === currentChart;
+            const isCurrent = selectedCoins.includes(coin.name);
             const CaretColorObject = getCaretAndColor(
               coin.price_change_percentage_24h_in_currency
             );

--- a/src/components/CoinSelectorCarousel/index.tsx
+++ b/src/components/CoinSelectorCarousel/index.tsx
@@ -68,7 +68,6 @@ const CoinedCard = tw.div<CoinCardProps>`
   shadow-md
   cursor-pointer
   text-lg
-  
   ${(props) =>
     props.$isCurrent
       ? `border-t-[1px] border-l-[1px] border-r-[1px] border-opacity-50

--- a/src/components/ModularChart/index.tsx
+++ b/src/components/ModularChart/index.tsx
@@ -94,7 +94,7 @@ export const ModularChart: React.FC<ChartProps> = ({ isPrice, coinData }) => {
           display: false,
         },
         ticks: {
-          display: hasAxis,
+          display: true,
         },
         border: {
           display: false,

--- a/src/components/ModularChart/index.tsx
+++ b/src/components/ModularChart/index.tsx
@@ -34,7 +34,6 @@ export type CoinDataProps = {
 };
 
 type ChartProps = {
-  hasAxis: boolean;
   isPrice: boolean;
   coinData: CoinDataProps;
 };
@@ -63,11 +62,7 @@ const ChartContainer = tw.div<ChartContainerProps>`
     props.$isPrice ? "dark:bg-d-price-chart" : "dark:bg-d-volume-chart"}
 `;
 
-export const ModularChart: React.FC<ChartProps> = ({
-  hasAxis,
-  isPrice,
-  coinData,
-}) => {
+export const ModularChart: React.FC<ChartProps> = ({ isPrice, coinData }) => {
   const chartRef = useRef<ChartJS<"line" | "bar", number[], string>>(null);
 
   const [gradientBackground, setGradientBackground] = useState<
@@ -77,11 +72,7 @@ export const ModularChart: React.FC<ChartProps> = ({
   const { theme, setTheme } = useTheme();
 
   const formattedData = () => {
-    if (hasAxis) {
-      return reducePoints(coinData.prices, 16);
-    } else {
-      return coinData.prices;
-    }
+    return reducePoints(coinData.prices, 16);
   };
 
   const getChartBackground = () => {

--- a/src/components/ModularChart/index.tsx
+++ b/src/components/ModularChart/index.tsx
@@ -141,7 +141,7 @@ export const ModularChart: React.FC<ChartProps> = ({ isLine, coinData }) => {
   const retreiveData = (index: number) => {
     if (coinData[index]) {
       if (isLine) {
-        return reducePoints(coinData[index].prices as [number, number][], 8);
+        return reducePoints(coinData[index].prices as [number, number][], 16);
       } else {
         return reducePoints(
           coinData[index].total_volumes as [number, number][],

--- a/src/components/ModularChart/index.tsx
+++ b/src/components/ModularChart/index.tsx
@@ -32,6 +32,7 @@ const options = {
       border: {
         display: false,
       },
+      stacked: true,
     },
     "y-axis-1": {
       display: false,
@@ -57,14 +58,14 @@ const options = {
 };
 
 const barFillColors = [
-  "rgba(165,94,221, 1)",
-  "rgba(255,168,0, 1)",
+  "rgba(165,94,221, .5)",
+  "rgba(120,120,255,.5)",
   "rgba(245,235,0, 1)",
 ];
 const lineFillColors = [
-  "rgba(120,120,255,0.33)",
-  "rgba(255,168,0, 0.33)",
-  "rgba(245,235,0, 0.33)",
+  "rgba(120,120,255,0.28)",
+  "rgba(165,94,221, .28)",
+  "rgba(245,235,0, .28)",
 ];
 
 ChartJS.register(
@@ -204,7 +205,7 @@ export const ModularChart: React.FC<ChartProps> = ({ isLine, coinData }) => {
           if (isLine) {
             startingGradient.addColorStop(0, lineFillColors[i]);
             startingGradient.addColorStop(1, getChartBackground());
-            borderArray.push({ color: lineFillColors[i], width: 2 });
+            borderArray.push({ color: lineFillColors[i], width: 4 });
           } else {
             startingGradient.addColorStop(0, barFillColors[i]);
             startingGradient.addColorStop(1, getChartBackground());

--- a/src/components/ModularChart/index.tsx
+++ b/src/components/ModularChart/index.tsx
@@ -56,6 +56,17 @@ const options = {
   borderWidth: 0,
 };
 
+const barFillColors = [
+  "rgba(165,94,221, 1)",
+  "rgba(255,168,0, 1)",
+  "rgba(245,235,0, 1)",
+];
+const lineFillColors = [
+  "rgba(120,120,255,0.33)",
+  "rgba(255,168,0, 0.33)",
+  "rgba(245,235,0, 0.33)",
+];
+
 ChartJS.register(
   CategoryScale,
   BarElement,
@@ -112,17 +123,6 @@ const ChartContainer = tw.div<ChartContainerProps>`
     props.$isLine ? "dark:bg-d-price-chart" : "dark:bg-d-volume-chart"}
 `;
 
-const barFillColors = [
-  "rgba(165,94,221, 1)",
-  "rgba(255,168,0, 1)",
-  "rgba(245,235,0, 1)",
-];
-const lineFillColors = [
-  "rgba(120,120,255,0.33)",
-  "rgba(255,168,0, 0.33)",
-  "rgba(245,235,0, 0.33)",
-];
-
 export const ModularChart: React.FC<ChartProps> = ({ isLine, coinData }) => {
   const chartRef = useRef<ChartJS<"line" | "bar", number[], string>>(null);
   const [finalChartData, setFinalChartData] = useState<ChartDataSetting[]>([]);
@@ -142,7 +142,10 @@ export const ModularChart: React.FC<ChartProps> = ({ isLine, coinData }) => {
       if (isLine) {
         return reducePoints(coinData[index].prices as [number, number][], 8);
       } else {
-        return reducePoints(coinData[index].prices as [number, number][], 16);
+        return reducePoints(
+          coinData[index].total_volumes as [number, number][],
+          16
+        );
       }
     } else {
       return [[0, 0]];
@@ -165,7 +168,6 @@ export const ModularChart: React.FC<ChartProps> = ({ isLine, coinData }) => {
 
   const populateDataSet = (coinData: ChartData[]): ChartDataSetting[] => {
     let dataSet: ChartDataSetting[] = [];
-    console.log("incomeing Coin:", coinData);
     coinData.forEach((coin, i) => {
       if (!isEmptyData(coinData[i]) && border[i]) {
         const currentData = {
@@ -181,7 +183,6 @@ export const ModularChart: React.FC<ChartProps> = ({ isLine, coinData }) => {
         };
         dataSet.push(currentData);
       }
-      console.log("outgoing data:", dataSet);
     });
     return dataSet;
   };

--- a/src/components/ModularChart/index.tsx
+++ b/src/components/ModularChart/index.tsx
@@ -17,6 +17,7 @@ import {
   BarController,
 } from "chart.js";
 import { reducePoints } from "@/utils/formatting";
+import { ChartData } from "@/app/GlobalRedux/Features/CoinChartSlice";
 
 ChartJS.register(
   CategoryScale,
@@ -35,7 +36,7 @@ export type CoinDataProps = {
 
 type ChartProps = {
   isPrice: boolean;
-  coinData: CoinDataProps;
+  coinData: ChartData[];
 };
 
 type ChartContainerProps = {
@@ -71,8 +72,12 @@ export const ModularChart: React.FC<ChartProps> = ({ isPrice, coinData }) => {
 
   const { theme, setTheme } = useTheme();
 
-  const formattedData = () => {
-    return reducePoints(coinData.prices, 16);
+  const retreiveData = (index: number) => {
+    if (coinData[index]) {
+      return reducePoints(coinData[index].prices as [number, number][], 16);
+    } else {
+      return ["", ""];
+    }
   };
 
   const getChartBackground = () => {
@@ -126,7 +131,7 @@ export const ModularChart: React.FC<ChartProps> = ({ isPrice, coinData }) => {
   }, [theme]);
 
   const data = {
-    labels: formattedData().map((price, i) => {
+    labels: retreiveData(0).map((price, i) => {
       let hour = new Date(price[0]).getHours();
       const amPm = hour >= 12 ? "PM" : "AM";
       hour = hour % 12;
@@ -137,7 +142,21 @@ export const ModularChart: React.FC<ChartProps> = ({ isPrice, coinData }) => {
       {
         fill: true,
         label: "Coin Price",
-        data: formattedData().map((price) => price[1]),
+        data: retreiveData(0).map((price) => price[1]),
+        backgroundColor: gradientBackground,
+        tension: 0.4,
+      },
+      {
+        fill: true,
+        label: "Coin Price",
+        data: retreiveData(1).map((price) => price[1]),
+        backgroundColor: gradientBackground,
+        tension: 0.4,
+      },
+      {
+        fill: true,
+        label: "Coin Price",
+        data: retreiveData(2).map((price) => price[1]),
         backgroundColor: gradientBackground,
         tension: 0.4,
       },

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -30,7 +30,7 @@ export const formatChartNumber = (num: number) => {
     const finalNum = (num / 1000000000000).toFixed(3);
     return `${finalNum} tln`;
   }
-  if (num > 1000000) {
+  if (num > 1000000000) {
     const finalNum = (num / 1000000000).toFixed(3);
     return `${finalNum} bln`;
   }

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -62,7 +62,10 @@ export const getCaretAndColor = (num: number) => {
   }
 };
 
-export const reducePoints = (arr: [number, number][], reduceBy: number) => {
+export const reducePoints = (
+  arr: [number, number][] = [],
+  reduceBy: number
+) => {
   return arr.filter((_, i) => i % reduceBy === 0);
 };
 


### PR DESCRIPTION
Coin Carousel can now select up to 3 coins and display the relative data in the relative graph. Modular charts have been adjusted to dynamically create datasets for graph, add tasteful styling, and account for checks and race conditions. ChartInfo will now display information of the first coin in the currentCharts state. Was thinking about changing this to the latest coin in the currentCharts state for better clarity. 